### PR TITLE
Remove rewrite rule

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -3,9 +3,6 @@ location PATHTOCHANGE {
        if ($scheme = http) {
             rewrite ^ https://$server_name$request_uri? permanent;
        }
-       if ($request_uri !~ index.php/$) {
-            rewrite ^PATHTOCHANGE/(.*)$ https://$server_namePATHTOCHANGE/index.php/$1 permanent;
-       }
        index index.php;
        try_files $uri $uri/ /index.php?$args;
        location ~ [^/]\.php(/|$) {


### PR DESCRIPTION
This commit reverts to state of 4c90f885c3364a52b971b66982b467be073943e2.
Rewrite are not followed by PUT request, which makes them unusable.
