### PR TITLE
[fix] service is named ffsync not firefox-sync

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -81,6 +81,6 @@ sudo service ffsync restart
 
 # Reload Nginx and regenerate SSOwat conf
 sudo service nginx reload
-sudo yunohost service add firefox-sync -l /var/log/ffsync.log
+sudo yunohost service add ffsync -l /var/log/ffsync.log
 sudo yunohost app setting ffsync skipped_uris -v "/"
 sudo yunohost app ssowatconf


### PR DESCRIPTION
there is a mistake, the service name is ffsync not firefox-sync