### PR TITLE
Update upgrade script

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -31,6 +31,9 @@ sed -i "s@PATHTOCHANGE@$path@g" ../conf/nginx.conf
 sed -i "s@ALIASTOCHANGE@$final_path/@g" ../conf/nginx.conf
 sudo cp ../conf/nginx.conf /etc/nginx/conf.d/$domain.d/ffsync.conf
 
+# stop service before upgrade
+service ffsync stop
+
 # Init virtualenv
 cd $final_path && sudo make build && sudo ./local/bin/easy_install gunicorn
 


### PR DESCRIPTION
When ffsync is running, we have an error while the upgrade :

The log of install :

```bash
+ sudo make build
virtualenv --python=`which python2 python | head -n 1` --no-site-packages ./local
New python executable in ./local/bin/python2
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/virtualenv.py", line 2378, in <module>
    main()
  File "/usr/lib/python3/dist-packages/virtualenv.py", line 830, in main
    symlink=options.symlink)
  File "/usr/lib/python3/dist-packages/virtualenv.py", line 999, in create_environment
    site_packages=site_packages, clear=clear, symlink=symlink))
  File "/usr/lib/python3/dist-packages/virtualenv.py", line 1316, in install_python
    shutil.copyfile(executable, py_executable)
  File "/usr/lib/python2.7/shutil.py", line 83, in copyfile
    with open(dst, 'wb') as fdst:
IOError: [Errno 26] Text file busy: './local/bin/python2'
Running virtualenv with interpreter /usr/bin/python2
Makefile:22: recipe for target 'local/COMPLETE' failed
make: *** [local/COMPLETE] Error 1
+ '[' -f /tmp/ffsync_swapfile ']'
```
Thanks